### PR TITLE
Refactor wild crops to use user-assignable tags

### DIFF
--- a/src/main/java/com/phantomwing/rusticdelight/world/ModWorldGeneration.java
+++ b/src/main/java/com/phantomwing/rusticdelight/world/ModWorldGeneration.java
@@ -7,6 +7,8 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BiomeTags;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.levelgen.GenerationStep;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 
@@ -15,15 +17,23 @@ public class ModWorldGeneration {
     public static final ResourceKey<PlacedFeature> WILD_COTTON_PLACED = registerKey("wild_cotton_placed");
     public static final ResourceKey<PlacedFeature> WILD_COFFEE_PLACED = registerKey("wild_coffee_placed");
 
+    public static final TagKey<Biome> HAS_WILD_COTTON = create("has_wild_cotton");
+    public static final TagKey<Biome> HAS_WILD_BELL_PEPPERS = create("has_wild_bell_peppers");
+    public static final TagKey<Biome> HAS_WILD_COFFEE = create("has_wild_coffee");
+
     public static ResourceKey<PlacedFeature> registerKey(String name) {
         return ResourceKey.create(Registries.PLACED_FEATURE, ResourceLocation.fromNamespaceAndPath(RusticDelight.MOD_ID, name));
+    }
+
+    private static TagKey<Biome> create(String name) {
+        return TagKey.create(Registries.BIOME, ResourceLocation.fromNamespaceAndPath(RusticDelight.MOD_ID, name));
     }
 
     public static void registerModWorldGeneration() {
         RusticDelight.LOGGER.info("Registering biome modifications for " + RusticDelight.MOD_ID);
 
-        BiomeModifications.addFeature(BiomeSelectors.tag(BiomeTags.IS_FOREST), GenerationStep.Decoration.VEGETAL_DECORATION, WILD_COTTON_PLACED);
-        BiomeModifications.addFeature(BiomeSelectors.tag(BiomeTags.IS_JUNGLE), GenerationStep.Decoration.VEGETAL_DECORATION, WILD_BELL_PEPPERS_PLACED);
-        BiomeModifications.addFeature(BiomeSelectors.tag(BiomeTags.IS_JUNGLE), GenerationStep.Decoration.VEGETAL_DECORATION, WILD_COFFEE_PLACED);
+        BiomeModifications.addFeature(BiomeSelectors.tag(HAS_WILD_COTTON), GenerationStep.Decoration.VEGETAL_DECORATION, WILD_COTTON_PLACED);
+        BiomeModifications.addFeature(BiomeSelectors.tag(HAS_WILD_BELL_PEPPERS), GenerationStep.Decoration.VEGETAL_DECORATION, WILD_BELL_PEPPERS_PLACED);
+        BiomeModifications.addFeature(BiomeSelectors.tag(HAS_WILD_COFFEE), GenerationStep.Decoration.VEGETAL_DECORATION, WILD_COFFEE_PLACED);
     }
 }

--- a/src/main/resources/data/rusticdelight/tags/worldgen/biome/has_wild_bell_peppers.json
+++ b/src/main/resources/data/rusticdelight/tags/worldgen/biome/has_wild_bell_peppers.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "#minecraft:is_jungle",
+    "#c:is_jungle"
+  ]
+}

--- a/src/main/resources/data/rusticdelight/tags/worldgen/biome/has_wild_coffee.json
+++ b/src/main/resources/data/rusticdelight/tags/worldgen/biome/has_wild_coffee.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "#minecraft:is_jungle",
+    "#c:is_jungle"
+  ]
+}

--- a/src/main/resources/data/rusticdelight/tags/worldgen/biome/has_wild_cotton.json
+++ b/src/main/resources/data/rusticdelight/tags/worldgen/biome/has_wild_cotton.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "#minecraft:is_forest",
+    "#c:is_forest"
+  ]
+}


### PR DESCRIPTION
Hi! This PR amends the wild crop placements to use tags specific to each crop, like how FD does. I wanted to tweak some crop spawns in a personal pack and figured it was wise to PR it to the mod itself.